### PR TITLE
chore(docs,ci,release): decommission project, add docs, bump to 1.0.0, build-only CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
-name: CI
+name: CI (decommissioned)
 on:
   - push
 jobs:
   build:
-    name: Build, lint, and test on Node ${{ matrix.node }} and ${{ matrix.os }}
+    name: Build only on Node ${{ matrix.node }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -20,17 +20,8 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Installation
-        run: yarn install
-      - name: Run zest unit tests
-        run: npx baldrick-broth test spec
-      - name: Run pest integration tests
-        run: npx baldrick-broth test pest
+        run: yarn install --frozen-lockfile
+      - name: Skip tests and lint (decommissioned)
+        run: echo "Project decommissioned — skipping tests and linting."
       - name: Build
         run: yarn build
-      - name: Test Report
-        uses: dorny/test-reporter@v1
-        if: success() || failure()
-        with:
-          name: Pest
-          path: report/*.pest.mocha.json
-          reporter: mocha-json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `src/` — TypeScript sources (ESM). Entry: `src/index.mts` (named exports).
+- `test/` — Node test runner specs: `*.test.ts`.
+- `spec/` — Declarative Zest examples: fixtures, snapshots, transformers.
+- Root configs: `tsconfig.json`, `.editorconfig`, `.prettierrc.json`, `.baldrick-zest.ts`.
+
+## Build, Test, and Development Commands
+- `yarn build` — Compile TypeScript to `dist/` with `tsc`.
+- `yarn test` — Run TS tests via Node test runner (`node --test` + `ts-node/esm`).
+- `yarn spec` — Run the Baldrick Zest demo/spec pipeline defined in `.baldrick-zest.ts`.
+- Requirements: Node `>=18`, ESM-only (`type: module`).
+
+## Coding Style & Naming Conventions
+- Indentation: 2 spaces; UTF-8; final newline (`.editorconfig`).
+- Formatting: Prettier (`.prettierrc.json`: 80 cols, semicolons, single quotes, trailing commas es5).
+- TypeScript: strict mode; prefer named exports; avoid CommonJS `require`.
+- Naming: files `kebab-case.ts`; types/interfaces `PascalCase`; functions/vars `camelCase`; constants `UPPER_SNAKE_CASE`.
+
+## Testing Guidelines
+- Framework: Node built-in test runner with TypeScript via `ts-node` loader.
+- Location: place tests in `test/` named `something.test.ts`.
+- Scope: add tests for new features and bug fixes; keep tests deterministic.
+- Zest specs: keep example data under `spec/fixtures` and snapshots in `spec/snapshots`; validate via `yarn spec`.
+
+## Commit & Pull Request Guidelines
+- Commits: concise, imperative subject; include context (e.g., refs like `(#12)`), group related changes.
+- PRs: clear summary, motivation, and scope; link issues; include before/after notes for behavior changes; update docs/specs/tests; ensure `yarn build` and `yarn test` pass.
+- CI/Compatibility: target Node 18+, ESM-only consumers.
+
+## Security & Configuration Tips
+- Do not commit secrets or tokens; no runtime secrets are required for build/test.
+- Prefer pure functions and validated inputs; see `src/testing-model.ts` and `TECHNICAL_DESIGN.md` for architecture context.

--- a/CODE_ANALYSIS.md
+++ b/CODE_ANALYSIS.md
@@ -1,0 +1,39 @@
+# Code Analysis
+
+## Overview
+Baldrick Zest Engine is an ESM TypeScript runner for declarative tests defined in YAML specs. It imports target functions, builds execution contexts, runs cases, and manages snapshots and reporting.
+
+## Key Features
+- Declarative spec loader: parses YAML into a strongly-typed `TestingModel` via Zod (`safeParseTestingModel`).
+- Function execution: supports pure functions with 1–3 params (`style: 'function a' | 'function a b' | 'function a b c'`).
+- Parameter sources: string literals or files with pluggable parsers; optional transformer pipeline per param.
+- Transformers: composable up to 5 steps; supports simple functions and higher-order `config -> function a`.
+- Tumble (table-driven): optional wrapper executes with object inputs to produce multiple results.
+- Snapshots: creates or compares snapshots (JSON/YAML/Text) using `jest-diff`; writes new files when missing.
+- Reporting: pretty console output (Chalk) and CI console; optional Mocha JSON report artifact.
+- Extensible I/O: `ExternalInjection` abstracts read/write/import and filename resolution.
+
+## Notable Modules
+- `src/index.mts` — entry `run(opts)`; loads spec, runs suite, writes Mocha JSON.
+- `testing-model.ts` — Zod schemas for specs, cases, transformers, tumble.
+- `testing-runner.ts` — orchestrates suite, handles TODO/SKIP, assertions, reporting.
+- `setup-execution-context.ts` — prepares params, expected snapshot, transformers, tumble.
+- `case-executor.ts` — imports and invokes target functions (1–3 args) with optional tumble.
+- `transformer-executor.ts` — loads and composes transformers.
+- `snapshot-creator.ts` — compare/write snapshots.
+- `reporter*.ts` — pretty/CI reporters and Mocha JSON expansion.
+
+## Spec Highlights (YAML)
+- Under test: `testing.style`, `testing.import`, `testing.function`.
+- Cases: map of named cases; `a: 'snapshot' | 'todo'`; params `[1..3]` each from `file|string` with optional `transform`.
+- Optional: `result.transform`, `snapshot` parser, `tumble` config+table.
+
+## Limits / TODOs
+- Schema defines `Class.method a` but executor currently handles only plain functions (1–3 args).
+- Transformers accept `staticMethodA` in schema, but runtime path treats it like a function import.
+- Tumble requires object inputs/outputs; strings are rejected.
+
+## Run Locally
+- Build: `yarn build`
+- Tests: `yarn test`
+- Spec demo: `yarn spec`

--- a/README.md
+++ b/README.md
@@ -1,60 +1,90 @@
 # baldrick-zest-engine
 
-![npm](https://img.shields.io/npm/v/baldrick-zest-engine) ![Build
-status](https://github.com/flarebyte/baldrick-zest-engine/actions/workflows/main.yml/badge.svg)
-![npm bundle
-size](https://img.shields.io/bundlephobia/min/baldrick-zest-engine)
-
-![npm type
-definitions](https://img.shields.io/npm/types/baldrick-zest-engine)
+![npm](https://img.shields.io/npm/v/baldrick-zest-engine)
+![Build status](https://github.com/flarebyte/baldrick-zest-engine/actions/workflows/main.yml/badge.svg)
+![npm bundle size](https://img.shields.io/bundlephobia/min/baldrick-zest-engine)
+![npm type definitions](https://img.shields.io/npm/types/baldrick-zest-engine)
 ![node-current](https://img.shields.io/node/v/baldrick-zest-engine)
 ![NPM](https://img.shields.io/npm/l/baldrick-zest-engine)
 
-> Run tests declaratively with a few cunning plans
+> Project status: Decommissioned
 
-Run tests declaratively with a few cunning plans
+This project explored a YAML-based format to author unit tests quickly. While useful in places, our current practice favors classic unit tests supported by generative AI and small helper libraries. As a result, baldrick-zest-engine is decommissioned and not recommended for new work.
 
 Highlights:
 
--   Written in `Typescript`
+- Written in `TypeScript` (ESM).
+
+## Why decommissioned?
+- Maintenance and onboarding costs outweighed benefits of YAML indirection.
+- Modern AI-assisted workflows make writing conventional tests fast and clearer.
+- Existing ecosystem tools (Node test runner, Vitest/Jest) cover the needs better.
+
+## Recommended approach
+- Write classic tests (Node `--test`, Vitest, or Jest) and use generative AI to scaffold cases.
+- Compose data shaping with helpers like:
+  - `object-crumble` for structured object mutation/abstraction
+  - `baldrick-zest-mess` for lightweight table-driven and diff helpers
+
+Example (Node test runner):
+
+```ts
+// test/my-feature.test.ts
+import { strict as assert } from 'node:assert';
+
+const addPrefix = (p: string, v: string) => `${p}${v}`;
+
+test('adds prefix', () => {
+  assert.equal(addPrefix('pre-', 'value'), 'pre-value');
+});
+
+// Table-driven
+for (const [p, v, out] of [
+  ['pre-', 'a', 'pre-a'],
+  ['x-', 'b', 'x-b'],
+]) {
+  test(`adds prefix ${p} to ${v}`, () => {
+    assert.equal(addPrefix(p, v), out);
+  });
+}
+```
+
+## Status and support
+- No new features planned; security updates only (if any).
+- Consider migrating YAML specs to equivalent TypeScript tests using the example above and helpers as needed.
 
 ## Documentation and links
 
--   [Code Maintenance](MAINTENANCE.md)
--   [Code Of Conduct](CODE_OF_CONDUCT.md)
--   [Api for baldrick-zest-engine](API.md)
--   [Contributing](CONTRIBUTING.md)
--   [Glossary](GLOSSARY.md)
--   [Diagram for the code base](INTERNAL.md)
--   [Vocabulary used in the code base](CODE_VOCABULARY.md)
--   [Architectural Decision Records](DECISIONS.md)
--   [Contributors](https://github.com/flarebyte/baldrick-zest-engine/graphs/contributors)
--   [Dependencies](https://github.com/flarebyte/baldrick-zest-engine/network/dependencies)
--   [Usage](USAGE.md)
+- Legacy docs (for reference only):
+  - [Code Maintenance](MAINTENANCE.md)
+  - [Code Of Conduct](CODE_OF_CONDUCT.md)
+  - [Api for baldrick-zest-engine](API.md)
+  - [Contributing](CONTRIBUTING.md)
+  - [Glossary](GLOSSARY.md)
+  - [Diagram for the code base](INTERNAL.md)
+  - [Vocabulary used in the code base](CODE_VOCABULARY.md)
+  - [Architectural Decision Records](DECISIONS.md)
+  - [Contributors](https://github.com/flarebyte/baldrick-zest-engine/graphs/contributors)
+  - [Dependencies](https://github.com/flarebyte/baldrick-zest-engine/network/dependencies)
+  - [Usage](USAGE.md)
 
 ## Related
 
--   [baldrick-zest-mess](https://github.com/flarebyte/baldrick-zest-mess)
+- Recommended: [baldrick-zest-mess](https://github.com/flarebyte/baldrick-zest-mess)
+- Recommended: [object-crumble](https://github.com/flarebyte/object-crumble)
 
-## Installation
+## Installation (legacy)
 
-This package is [ESM
-only](https://blog.sindresorhus.com/get-ready-for-esm-aa53530b3f77).
-
-```bash
-yarn global add baldrick-zest-engine
-baldrick-zest-engine --help
-```
-
-Or alternatively run it:
+This package is ESM-only. Installation is not recommended for new projects; retained for archival testing only.
 
 ```bash
 npx baldrick-zest-engine --help
 ```
 
-If you want to tun the latest version from github. Mostly useful for dev:
+To inspect the repository locally:
 
 ```bash
-git clone git@github.com:flarebyte/baldrick-zest-engine.git
-yarn global add `pwd`
+git clone https://github.com/flarebyte/baldrick-zest-engine.git
+cd baldrick-zest-engine
+yarn
 ```

--- a/baldrick-broth.yaml
+++ b/baldrick-broth.yaml
@@ -1,7 +1,7 @@
 model:
   project:
-    title: Run tests declaratively with a few cunning plans
-    description: Run tests declaratively with a few cunning plans
+    title: [Decommissioned] Run tests declaratively with a few cunning plans
+    description: DECOMMISSIONED — Prefer classic unit tests with AI assistance and helpers; see README for migration guidance.
     version: 1.0.0
     keywords:
       - unit-testing
@@ -13,6 +13,7 @@ model:
       - ESM
   readme:
     highlights:
+      - Project decommissioned — use conventional tests instead
       - Written in `Typescript`
     links:
       - "[Usage](USAGE.md)"

--- a/baldrick-broth.yaml
+++ b/baldrick-broth.yaml
@@ -2,7 +2,7 @@ model:
   project:
     title: Run tests declaratively with a few cunning plans
     description: Run tests declaratively with a few cunning plans
-    version: 0.9.0
+    version: 1.0.0
     keywords:
       - unit-testing
       - testing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baldrick-zest-engine",
-  "description": "Run tests declaratively with a few cunning plans",
+  "description": "DECOMMISSIONED: Prefer classic unit tests with AI assistance; see README for migration.",
   "version": "1.0.0",
   "author": {
     "name": "Olivier Huin",
@@ -13,7 +13,9 @@
     "assert",
     "expect",
     "snapshot",
-    "ESM"
+    "ESM",
+    "decommissioned",
+    "deprecated"
   ],
   "license": "MIT",
   "homepage": "https://github.com/flarebyte/baldrick-zest-engine",
@@ -44,7 +46,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "tsc --outDir dist",
+    "build": "rm -rf dist && tsc --outDir dist",
     "test": "node --test --loader ts-node/esm test/*.test.ts",
     "spec": "node --loader ts-node/esm .baldrick-zest.ts"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baldrick-zest-engine",
   "description": "Run tests declaratively with a few cunning plans",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "author": {
     "name": "Olivier Huin",
     "url": "https://github.com/olih"

--- a/src/index.mts
+++ b/src/index.mts
@@ -1,41 +1,27 @@
-import { reportMochaJson } from './mocha-json-reporter.js';
-import { ReportTracker } from './reporter-model.js';
-import { getZestYaml } from './testing-io.js';
-import { runZestFileSuite } from './testing-runner.js';
 import type { TestingRunOpts } from './run-opts-model.js';
-
-const createReportTracker = (): ReportTracker => ({
-  stats: {
-    suites: 1,
-    tests: 0,
-    passes: 0,
-    failures: 0,
-    pending: 0,
-    start: new Date().toISOString(),
-    end: '',
-    duration: Date.now(),
-  },
-  tests: [],
-});
 
 /**
  * Run the tests
  * @param opts options for the run
  */
-export const run = async (opts: TestingRunOpts) => {
-  const result = await getZestYaml(opts.inject, opts.specFile);
-  if (result.status === 'failure') {
-    console.error(result);
-  } else if (result.status === 'success') {
-    const reportTracker = createReportTracker();
-    const suiteOps = {
-      reportTracker,
-      runOpts: opts,
-      testingModel: result.value,
-    };
-    await runZestFileSuite(suiteOps);
-    if (opts.mochaJsonReport) {
-      await reportMochaJson(suiteOps);
-    }
-  }
+export const run = async (_opts: TestingRunOpts) => {
+  const message =
+    'baldrick-zest-engine has been decommissioned. See README for rationale and migration guidance.';
+  throw new Error(message);
+  // Previous implementation retained below for archival reference only.
+  // const result = await getZestYaml(opts.inject, opts.specFile);
+  // if (result.status === 'failure') {
+  //   console.error(result);
+  // } else if (result.status === 'success') {
+  //   const reportTracker = createReportTracker();
+  //   const suiteOps = {
+  //     reportTracker,
+  //     runOpts: opts,
+  //     testingModel: result.value,
+  //   };
+  //   await runZestFileSuite(suiteOps);
+  //   if (opts.mochaJsonReport) {
+  //     await reportMochaJson(suiteOps);
+  //   }
+  // }
 };

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.9.0';
+export const version = '1.0.0';


### PR DESCRIPTION
Summary
- Decommissions baldrick-zest-engine in favor of conventional tests with AI help.
- Adds AGENTS.md and CODE_ANALYSIS.md.
- Bumps version to 1.0.0; marks decommissioning release.
- Disables tests/lint in CI; build-only workflow.
- Marks metadata as decommissioned in package.json and baldrick-broth.yaml.

Rationale
- YAML indirection increased maintenance/onboarding cost.
- AI-assisted workflows make writing standard tests faster and clearer.
- Existing runners (Node --test, Vitest, Jest) and helpers cover needs.

Changes
- README.md: decommission notice, rationale, migration guidance + example.
- AGENTS.md: repo guidelines (structure, commands, style, testing, PR).
- CODE_ANALYSIS.md: features, modules, spec, limits/TODOs.
- src/index.mts: run() now throws decommission message.
- Version: 0.9.0 -> 1.0.0 (package.json, src/version.ts, baldrick-broth.yaml).
- CI: main workflow renamed/simplified to build-only.
- package.json: description/keywords updated to indicate decommissioned status.
- baldrick-broth.yaml: project title/description/highlights updated to indicate decommissioned status.

Breaking Changes
- Entry point now throws on invocation.
- CI no longer runs zest/pest tests or uploads reports.

Migration
- Prefer Node test runner, Vitest, or Jest.
- Helpers: object-crumble; baldrick-zest-mess.
- See README “Recommended approach”.

Checklist
- [x] Docs updated
- [x] Version bumped to 1.0.0
- [x] CI updated to build-only
- [x] Metadata updated to reflect decommissioned status
- [x] Build passes (yarn build)
